### PR TITLE
chore: init CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+/apis/poi/ @sebprev
+/apis/trips/ @ludlalande
+/apis/user-java/ @ecnabogs
+/apis/userprofile/ @miklk
+/iac/ @n-scope


### PR DESCRIPTION
closes #2
Init code owners file.